### PR TITLE
adb check is  unnessary

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -770,7 +770,7 @@ function extract() {
     local SRC="$2"
     local OUTPUT_ROOT="$CM_ROOT"/"$OUTDIR"/proprietary
     local OUTPUT_TMP="$TMPDIR"/"$OUTDIR"/proprietary
-    #adb reboot to recovery
+    #adb reboot recovery 
     #if [ "$SRC" = "adb" ]; then
     #    init_adb_connection
     #fi

--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -770,10 +770,10 @@ function extract() {
     local SRC="$2"
     local OUTPUT_ROOT="$CM_ROOT"/"$OUTDIR"/proprietary
     local OUTPUT_TMP="$TMPDIR"/"$OUTDIR"/proprietary
-
-    if [ "$SRC" = "adb" ]; then
-        init_adb_connection
-    fi
+    #adb reboot to recovery
+    #if [ "$SRC" = "adb" ]; then
+    #    init_adb_connection
+    #fi
 
     if [ "$VENDOR_STATE" -eq "0" ]; then
         echo "Cleaning output directory ($OUTPUT_ROOT).."


### PR DESCRIPTION
we can not pull vendor file from device when be RECOVERY MODE.