### PR TITLE
Old APN-information Telia Finland

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -892,10 +892,8 @@
   <apn carrier="Saunalahti Wap" mcc="244" mnc="21" apn="wap.saunalahti.fi" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="Saunalahti Internet" mcc="244" mnc="21" apn="internet.saunalahti" proxy="" port="" user="" password="" mmsc="" authtype="1" type="default,supl" />
   <apn carrier="Saunalahti MMS" mcc="244" mnc="21" apn="mms.saunalahti.fi" proxy="" port="" user="" password="" mmsc="http://mms.saunalahti.fi:8002/" mmsproxy="62.142.4.197" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="Sonera Internet" mcc="244" mnc="91" apn="internet" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Sonera MMS" mcc="244" mnc="91" apn="wap.sonera.net" proxy="" port="" user="" password="" mmsc="http://mms.sonera.fi:8002" mmsproxy="195.156.25.33" mmsport="80" type="mms" />
-  <apn carrier="Tele Finland Internet" mcc="244" mnc="91" apn="internet" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Tele Finland MMS" mcc="244" mnc="91" apn="wap.sonera.net" proxy="" port="" user="" password="" mmsc="http://mms.sonera.fi:8002" mmsproxy="195.156.25.33" mmsport="80" type="mms" />
+  <apn carrier="Telia Internet" mcc="244" mnc="91" apn="internet" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
+  <apn carrier="Telia MMS" mcc="244" mnc="91" apn="mms" proxy="" port="" user="" password="" mmsc="http://mms/" mmsproxy="195.156.25.33" mmsport="8080" type="mms" />
   <apn carrier="Omnitel MMS" mcc="246" mnc="01" apn="gprs.mms.lt" proxy="" port="" user="mms" password="mms" mmsc="http://mms.omnitel.net:8002/" mmsproxy="194.176.32.149" mmsport="8080" type="mms" />
   <apn carrier="Omnitel" mcc="246" mnc="01" apn="gprs.startas.lt" proxy="" port="" user="omni" password="omni" mmsc="" type="default,supl" />
   <apn carrier="Omnitel Internet" mcc="246" mnc="01" apn="omnitel" proxy="" port="" user="omni" password="omni" mmsc="" type="default,supl" />


### PR DESCRIPTION
Old information in apns-conf.xml -file relating to Telia Finland Oyj (former Sonera and Tele Finland). In spring Telia Company merged its two Finnish subsidiaries together (Sonera and Tele Finland) and at the same time changed the name to new Telia Finland (or shortly just Telia).

They also changed APN settings which are now same to former Sonera ja Tele Finland customers and also to new Telia Finland customers. APN information: https://www.telia.fi/asiakastuki/liittymat/puhelimen-kaytto/mms-internet-asetukset (sorry only in Finnish but nevertheless experienced user can found and verify information).

I can confirm that those new APN settings works like they should, both internet and MMS; I'm Telia customer with same MCC&MNC -codes.